### PR TITLE
fixing extended assembly when a register is already used in the template

### DIFF
--- a/README.md
+++ b/README.md
@@ -353,7 +353,7 @@ Example of diagram generated with -dotfile parameter :
 ## release notes
 
 
-1.0.18    adding install and uninstall in makefile (#PR24 from rurban). Adding ND_MOD in is_const_expr(#issue 134 from matthewsot). Fixing incorrect small struct passing in 5th argument position (issue #127 from sgraham). Fixing ISS-140 compiling chibicc with chibicc tests failed with trying to parse the object.o file instead of linking only. Fixing some issues with extended assembly (ISS-141) and reformating some but still have one issue with ASSERT used after assembly inline in some case (see ./issues/assign1.c)
+1.0.19    fixing extended assembly issue when a register is already used in the template, the variable should be stored in another register available.
 
 ## old release notes
 

--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -50,3 +50,5 @@ Fixing issue #119 about cmathcalls. Removing fix for #119 caused an infinite loo
 Fixing issue #131 (ISS-131) parsing issue when trying to compile nginx project caused by fix #121. Adding some projects to test in Makefile because sometimes some fixes cause side effects!
 
 1.0.17 Fixing ISS-129 need to manage output other than "=r". Fixing ISS-139 extended assembly compiling but execution doesn't return the correct result. Fixing temporary ISS-142 caused by join_adjacent_string_literals function.
+
+1.0.18    adding install and uninstall in makefile (#PR24 from rurban). Adding ND_MOD in is_const_expr(#issue 134 from matthewsot). Fixing incorrect small struct passing in 5th argument position (issue #127 from sgraham). Fixing ISS-140 compiling chibicc with chibicc tests failed with trying to parse the object.o file instead of linking only. Fixing some issues with extended assembly (ISS-141) and reformating some but still have one issue with ASSERT used after assembly inline in some case (see ./issues/assign1.c)

--- a/chibicc.h
+++ b/chibicc.h
@@ -31,7 +31,7 @@
 #endif
 
 #define PRODUCT "chibicc"
-#define VERSION "1.0.18"
+#define VERSION "1.0.19"
 #define MAXLEN 101
 #define DEFAULT_TARGET_MACHINE "x86_64-linux-gnu"
 
@@ -521,6 +521,15 @@ char *reg_bx(int sz);
 char *reg_cx(int sz);
 char *reg_dx(int sz);
 void assign_lvar_offsets_assembly(Obj *fn);
+int add_register_used(char *regist);
+void clear_register_used();
+char *register32_to_64(char *regist);
+char *register16_to_64(char *regist);
+char *register8_to_64(char *regist);
+char *register_available();  
+char *specific_register_available(char *regist); 
+int check_register_used(char *regist);
+void check_register_in_template(char *template); 
 
 //
 // unicode.c

--- a/extended_asm.c
+++ b/extended_asm.c
@@ -133,15 +133,16 @@ char *extended_asm(Node *node, Token **rest, Token *tok, Obj *locals)
     asmExt->template->templatestr = template;
     asmExt->template->hasPercent = check_template(template);
     char *input_asm_str;
-    //char *output_str;
     char *output_loading;
-    //char *input_str;
     asmtype = 0;
     nbInput = 0;
     nbOutput = 0;
     nbClobber = 0;
     nbLabel = 0;
-    
+    //clear the registerUsed array
+    clear_register_used();
+    //mark the register used if found in template
+    check_register_in_template(template);
     
     while (!equal(tok->next, ";") && !equal(tok, ";"))
     {
@@ -223,7 +224,7 @@ char *extended_asm(Node *node, Token **rest, Token *tok, Obj *locals)
     asm_str = subst_asm(asm_str, " {", "%{");
     asm_str = subst_asm(asm_str, " |", "%|");
     asm_str = subst_asm(asm_str, " }", "%}");
-    
+    //printf("=====%s\n", asm_str);
     *rest = tok;
     // free memory
     for (int i = 0; i < 10; i++)
@@ -253,7 +254,7 @@ void output_asm(Node *node, Token **rest, Token *tok, Obj *locals)
                     asmExt->output[nbOutput]->prefix = "=";
                 else
                     asmExt->output[nbOutput]->prefix = "+";
-                asmExt->output[nbOutput]->reg = "%rax";
+                asmExt->output[nbOutput]->reg = specific_register_available("%rax");
                 asmExt->output[nbOutput]->letter = 'r';
                 asmExt->output[nbOutput]->variableNumber = retrieveVariableNumber(nbOutput);
                 
@@ -265,7 +266,7 @@ void output_asm(Node *node, Token **rest, Token *tok, Obj *locals)
                     asmExt->output[nbOutput]->prefix = "=";
                 else
                     asmExt->output[nbOutput]->prefix = "+";
-                asmExt->output[nbOutput]->reg = "%rax";
+                asmExt->output[nbOutput]->reg = specific_register_available("%rax");
                 asmExt->output[nbOutput]->letter = 'm';
                 asmExt->output[nbOutput]->variableNumber = retrieveVariableNumber(nbOutput);
                 
@@ -275,23 +276,23 @@ void output_asm(Node *node, Token **rest, Token *tok, Obj *locals)
             {
                 if (!strncmp(tok->str, "=a", tok->len))
                 {
-                    asmExt->output[nbOutput]->reg = "%rax";
+                    asmExt->output[nbOutput]->reg = specific_register_available("%rax");
                     asmExt->output[nbOutput]->letter = 'a';
 
                 }
                 else if (!strncmp(tok->str, "=b", tok->len))
                 {
-                    asmExt->output[nbOutput]->reg = "%rbx";
+                    asmExt->output[nbOutput]->reg = specific_register_available("%rbx");
                     asmExt->output[nbOutput]->letter = 'b';
                 }
                 else if (!strncmp(tok->str, "=c", tok->len))
                 {
-                    asmExt->output[nbOutput]->reg = "%rcx";
+                    asmExt->output[nbOutput]->reg = specific_register_available("%rcx");
                     asmExt->output[nbOutput]->letter = 'c';
                 }
                 else if (!strncmp(tok->str, "=d", tok->len))
                 {
-                    asmExt->output[nbOutput]->reg = "%rdx";
+                    asmExt->output[nbOutput]->reg = specific_register_available("%rdx");
                     asmExt->output[nbOutput]->letter = 'd';
                 }
                 else

--- a/test/assign1.c
+++ b/test/assign1.c
@@ -1,8 +1,8 @@
 #include <stdio.h>
-#include "../test/test.h"
+#include "test.h"
 int main() {
     int a = 0;
-    //printf("a = %d\n", a);
+    printf("a = %d\n", a);
     int b;
     b = a;
     ASSERT(0, a);
@@ -13,12 +13,10 @@ int main() {
     );
 
     __asm__ ("movl %eax, %0;" : "=r" ( a ));
-    //printf("a = %d\n", a);
+    printf("a = %d\n", a);
     b = a;
     ASSERT(30, a);
     ASSERT(30, b);
-    //test/assign1.exe
-    // a = 0
-    // a => 30 expected but got 21948
-    // make: *** [Makefile:29: test] Error 1
+    printf("a = %d, b = %d \n", a, b);
+    return 0;
 }


### PR DESCRIPTION
1.0.19    
- fixing extended assembly issue when a register is already used in the template, the variable should be stored in another register available.