### PR TITLE
Fix function declarations with shared return type

### DIFF
--- a/parse.c
+++ b/parse.c
@@ -4252,7 +4252,7 @@ static Token *function(Token *tok, Type *basety, VarAttr *attr)
 
   fn->is_root = !(fn->is_static && fn->is_inline);
 
-  if (consume(&tok, tok, ";"))
+  if (consume(&tok, tok, ";") || consume(&tok, tok, ","))
     return tok;
 
   current_fn = fn;

--- a/test/function.c
+++ b/test/function.c
@@ -88,6 +88,8 @@ unsigned short ushort_fn();
 char schar_fn();
 short sshort_fn();
 
+int multiple1(), multiple2();
+
 int add_all(int n, ...);
 
 typedef struct


### PR DESCRIPTION
Parsing would fail on multiple function declarations with shared return types, for example: int multiple1(), multiple2();