### PR TITLE
Copyright of Cosmopolitan and slimcc

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,6 +1,8 @@
 MIT License
 
 Copyright (c) 2019 Rui Ueyama
+Copyright (c) 2020 Justine Alexandra Roberts Tunney
+Copyright (c) 2023-2026 Hsiang-Ying Fu
 
 Permission is hereby granted, free of charge, to any person obtaining a copy
 of this software and associated documentation files (the "Software"), to deal


### PR DESCRIPTION
Hi, the project has been incorporating features and fixes from the Cosmopolitan fork and slimcc, and is now shipping with slimcc's test files. I think it's great that you detailed the fact in source comments and changelogs, just missing copyright bits in LICENSE.
